### PR TITLE
mwifiex: using right tid for addressing ra_list

### DIFF
--- a/recipes-kernel/linux/files/0001-mwifiex-using-right-tid-for-addressing-ra_list.patch
+++ b/recipes-kernel/linux/files/0001-mwifiex-using-right-tid-for-addressing-ra_list.patch
@@ -1,0 +1,89 @@
+From 719a25e33153bcfe842243710826f1426c7accfc Mon Sep 17 00:00:00 2001
+From: Xinming Hu <huxm@marvell.com>
+Date: Wed, 3 Jun 2015 16:59:46 +0530
+Subject: [PATCH] mwifiex: using right tid for addressing ra_list
+
+This patch fixes issue with the accessing correct ra_list by
+downgrading corresponding tid number.
+
+Alternatively, ra lists are created in mwifiex_wmm_add_buf_txqueue
+using downgraded tid number.
+
+Signed-off-by: Xinming Hu <huxm@marvell.com>
+Signed-off-by: Cathy Luo <cluo@marvell.com>
+Signed-off-by: Avinash Patil <patila@marvell.com>
+Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
+Signed-off-by: De Huo <De.Huo@windriver.com>
+---
+ drivers/net/wireless/mwifiex/11n.c           | 11 ++++++++---
+ drivers/net/wireless/mwifiex/11n_rxreorder.c |  5 ++++-
+ 2 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/net/wireless/mwifiex/11n.c b/drivers/net/wireless/mwifiex/11n.c
+index 433bd68..e9a1443 100644
+--- a/drivers/net/wireless/mwifiex/11n.c
++++ b/drivers/net/wireless/mwifiex/11n.c
+@@ -156,7 +156,7 @@ int mwifiex_ret_11n_delba(struct mwifiex_private *priv,
+ int mwifiex_ret_11n_addba_req(struct mwifiex_private *priv,
+ 			      struct host_cmd_ds_command *resp)
+ {
+-	int tid;
++	int tid, tid_down;
+ 	struct host_cmd_ds_11n_addba_rsp *add_ba_rsp = &resp->params.add_ba_rsp;
+ 	struct mwifiex_tx_ba_stream_tbl *tx_ba_tbl;
+ 	struct mwifiex_ra_list_tbl *ra_list;
+@@ -167,7 +167,9 @@ int mwifiex_ret_11n_addba_req(struct mwifiex_private *priv,
+ 
+ 	tid = (block_ack_param_set & IEEE80211_ADDBA_PARAM_TID_MASK)
+ 	       >> BLOCKACKPARAM_TID_POS;
+-	ra_list = mwifiex_wmm_get_ralist_node(priv, tid, add_ba_rsp->
++
++	tid_down = mwifiex_wmm_downgrade_tid(priv, tid);
++	ra_list = mwifiex_wmm_get_ralist_node(priv, tid_down, add_ba_rsp->
+ 		peer_mac_addr);
+ 	if (le16_to_cpu(add_ba_rsp->status_code) != BA_RESULT_SUCCESS) {
+ 		if (ra_list) {
+@@ -528,13 +530,16 @@ void mwifiex_create_ba_tbl(struct mwifiex_private *priv, u8 *ra, int tid,
+ 	struct mwifiex_tx_ba_stream_tbl *new_node;
+ 	struct mwifiex_ra_list_tbl *ra_list;
+ 	unsigned long flags;
++	int tid_down;
+ 
+ 	if (!mwifiex_get_ba_tbl(priv, tid, ra)) {
+ 		new_node = kzalloc(sizeof(struct mwifiex_tx_ba_stream_tbl),
+ 				   GFP_ATOMIC);
+ 		if (!new_node)
+ 			return;
+-		ra_list = mwifiex_wmm_get_ralist_node(priv, tid, ra);
++
++		tid_down = mwifiex_wmm_downgrade_tid(priv, tid);
++		ra_list = mwifiex_wmm_get_ralist_node(priv, tid_down, ra);
+ 		if (ra_list) {
+ 			ra_list->ba_status = ba_status;
+ 			ra_list->amsdu_in_ampdu = false;
+diff --git a/drivers/net/wireless/mwifiex/11n_rxreorder.c b/drivers/net/wireless/mwifiex/11n_rxreorder.c
+index f75f8ac..7f1e44e 100644
+--- a/drivers/net/wireless/mwifiex/11n_rxreorder.c
++++ b/drivers/net/wireless/mwifiex/11n_rxreorder.c
+@@ -662,6 +662,7 @@ mwifiex_del_ba_tbl(struct mwifiex_private *priv, int tid, u8 *peer_mac,
+ 	struct mwifiex_ra_list_tbl *ra_list;
+ 	u8 cleanup_rx_reorder_tbl;
+ 	unsigned long flags;
++	int tid_down;
+ 
+ 	if (type == TYPE_DELBA_RECEIVE)
+ 		cleanup_rx_reorder_tbl = (initiator) ? true : false;
+@@ -687,7 +688,9 @@ mwifiex_del_ba_tbl(struct mwifiex_private *priv, int tid, u8 *peer_mac,
+ 				"event: TID, RA not found in table\n");
+ 			return;
+ 		}
+-		ra_list = mwifiex_wmm_get_ralist_node(priv, tid, peer_mac);
++
++		tid_down = mwifiex_wmm_downgrade_tid(priv, tid);
++		ra_list = mwifiex_wmm_get_ralist_node(priv, tid_down, peer_mac);
+ 		if (ra_list) {
+ 			ra_list->amsdu_in_ampdu = false;
+ 			ra_list->ba_status = BA_SETUP_NONE;
+-- 
+2.7.4
+

--- a/recipes-kernel/linux/linux-yocto_4.1.bbappend
+++ b/recipes-kernel/linux/linux-yocto_4.1.bbappend
@@ -78,6 +78,7 @@ SRC_URI += "file://apollolake-standard.scc \
 	    file://0017-x86-fpu-Don-t-let-userspace-set-bogus-xcomp_bv.patch \
 	    file://0018-packet-hold-bind-lock-when-rebinding-to-fanout-hook.patch \
 	    file://0019-packet-in-packet_do_bind-test-fanout-with-bind_lock-.patch \
+	    file://0001-mwifiex-using-right-tid-for-addressing-ra_list.patch \
 	   "
 
 KERNEL_MODULE_PROBECONF += "rsi_usb"


### PR DESCRIPTION
Add patch to fix issue with the accessing correct ra_list by
downgrading corresponding tid number.

Alternatively, ra lists are created in mwifiex_wmm_add_buf_txqueue
using downgraded tid number.

Signed-off-by: De Huo <De.Huo@windriver.com>